### PR TITLE
Refine Obstacle Dash UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# obstacle-dash
-Build an endless runner game called “Obstacle Dash” 
+# Obstacle Dash
+
+A simple endless runner game built with HTML, CSS and JavaScript. Guide the blocky runner and avoid falling crates and ground barriers. The speed increases every 15 seconds so stay sharp!
+
+* Use **Up Arrow** to jump.
+* Use **Down Arrow** to slide.
+* The game tracks your score based on survival time.
+* Current speed is shown in the top-right corner and increases every 15 seconds.
+* When you collide with an obstacle, a game over screen appears with a retry button.
+
+The layout maintains a responsive 3:2 ratio and uses flat design with bright colors.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Obstacle Dash</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="game-wrapper">
+        <div id="score">Score: 0</div>
+        <div id="speed">Speed: 4</div>
+        <div id="game-area">
+            <div id="player" class="run"></div>
+        </div>
+        <div id="overlay" class="hidden" style="display:none;">
+            <div id="game-over">Game Over</div>
+            <button id="retry">Retry</button>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,158 @@
+const gameArea = document.getElementById('game-area');
+const playerEl = document.getElementById('player');
+const scoreEl = document.getElementById('score');
+const overlay = document.getElementById('overlay');
+const retryBtn = document.getElementById('retry');
+const speedEl = document.getElementById('speed');
+
+let player = {
+    x: 30,
+    y: 0,
+    width: 40,
+    height: 60,
+    vy: 0,
+    jumping: false,
+    sliding: false
+};
+
+let obstacles = [];
+let obstacleTimer = 0;
+let speed = 4;
+let score = 0;
+let lastTime = null;
+let speedTimer = 0;
+let gameOver = false;
+
+function reset() {
+    obstacles.forEach(o => o.el.remove());
+    obstacles = [];
+    player.y = 0;
+    player.vy = 0;
+    player.jumping = false;
+    player.sliding = false;
+    playerEl.style.bottom = '10px';
+    playerEl.style.height = '60px';
+    playerEl.className = 'run';
+    obstacleTimer = 0;
+    speed = 4;
+    score = 0;
+    speedTimer = 0;
+    lastTime = null;
+    gameOver = false;
+    overlay.classList.add('hidden');
+    overlay.style.display = 'none';
+    speedEl.textContent = 'Speed: ' + speed;
+    requestAnimationFrame(loop);
+}
+
+function spawnObstacle() {
+    const el = document.createElement('div');
+    el.classList.add('obstacle');
+    gameArea.appendChild(el);
+    const obs = {
+        x: gameArea.clientWidth,
+        width: 40,
+        height: 60,
+        el
+    };
+    obstacles.push(obs);
+}
+
+function updatePlayer(dt) {
+    if (player.jumping) {
+        player.vy += 0.8; // gravity
+        player.y += player.vy;
+        if (player.y > 0) {
+            player.y = 0;
+            player.vy = 0;
+            player.jumping = false;
+            playerEl.classList.remove('jump');
+            playerEl.classList.add('run');
+        }
+        playerEl.style.bottom = 10 + player.y + 'px';
+    }
+}
+
+function updateObstacles(dt) {
+    for (let i = obstacles.length - 1; i >= 0; i--) {
+        const o = obstacles[i];
+        o.x -= speed;
+        if (o.x + o.width < 0) {
+            o.el.remove();
+            obstacles.splice(i, 1);
+            continue;
+        }
+        o.el.style.left = o.x + 'px';
+    }
+}
+
+function checkCollision() {
+    const playerRect = playerEl.getBoundingClientRect();
+    for (const o of obstacles) {
+        const oRect = o.el.getBoundingClientRect();
+        if (playerRect.left < oRect.right &&
+            playerRect.right > oRect.left &&
+            playerRect.top < oRect.bottom &&
+            playerRect.bottom > oRect.top) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function loop(timestamp) {
+    if (gameOver) return;
+    if (!lastTime) lastTime = timestamp;
+    const dt = timestamp - lastTime;
+    lastTime = timestamp;
+
+    obstacleTimer += dt;
+    speedTimer += dt;
+    if (obstacleTimer > 1500 / (speed / 4)) {
+        spawnObstacle();
+        obstacleTimer = 0;
+    }
+    if (speedTimer > 15000) {
+        speed += 1;
+        speedTimer = 0;
+        speedEl.textContent = 'Speed: ' + speed;
+    }
+
+    updatePlayer(dt);
+    updateObstacles(dt);
+
+    score += dt * 0.01;
+    scoreEl.textContent = 'Score: ' + Math.floor(score);
+
+    if (checkCollision()) {
+        gameOver = true;
+        overlay.classList.remove('hidden');
+        overlay.style.display = 'flex';
+        return;
+    }
+
+    requestAnimationFrame(loop);
+}
+
+window.addEventListener('keydown', (e) => {
+    if (e.code === 'ArrowUp' && !player.jumping && !player.sliding) {
+        player.jumping = true;
+        player.vy = -15;
+        playerEl.classList.remove('run');
+        playerEl.classList.add('jump');
+    } else if (e.code === 'ArrowDown' && !player.jumping) {
+        player.sliding = true;
+        playerEl.style.height = '30px';
+    }
+});
+
+window.addEventListener('keyup', (e) => {
+    if (e.code === 'ArrowDown') {
+        player.sliding = false;
+        playerEl.style.height = '60px';
+    }
+});
+
+retryBtn.addEventListener('click', reset);
+
+reset();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,96 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: #d0e6ff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+#game-wrapper {
+    position: relative;
+    width: 90vmin;
+    height: calc(90vmin * 2 / 3); /* 3:2 ratio */
+    background: #8ee4af;
+    overflow: hidden;
+    box-shadow: 0 0 10px rgba(0,0,0,0.3);
+}
+
+#game-area {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    top: 0;
+}
+
+#player {
+    position: absolute;
+    bottom: 10px;
+    left: 30px;
+    width: 40px;
+    height: 60px;
+    background: #ff6f69;
+    transition: height 0.1s;
+}
+
+.obstacle {
+    position: absolute;
+    bottom: 10px;
+    width: 40px;
+    height: 60px;
+    background: #588b8b;
+}
+
+#score {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    color: #fff;
+    font-size: 20px;
+    z-index: 2;
+}
+
+#speed {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    color: #fff;
+    font-size: 20px;
+    z-index: 2;
+    font-family: monospace;
+}
+
+#overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.7);
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    z-index: 3;
+}
+
+.hidden {
+    display: none;
+}
+
+button {
+    padding: 10px 20px;
+    border: none;
+    background: #ffcc5c;
+    color: #333;
+    font-size: 16px;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #ffd369;
+}


### PR DESCRIPTION
## Summary
- hide Game Over overlay until collision occurs
- spawn only ground obstacles and remove top obstacle CSS
- display current speed in the top-right of the screen
- update README with speed indicator info

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e8ea2ff8083239fd47f43e03be8b1